### PR TITLE
feat: make axios timeout configurable via SDKConfig

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ class FiscalSDK {
   constructor(config: SDKConfig) {
     this.axios = axios.create({
       baseURL: config.host,
-      timeout: 1000,
+      timeout: config.timeout ?? 1000,
       headers: { "Content-Type": "text/xml" },
     });
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,7 @@
 export interface SDKConfig {
   host: string;
+  /** Axios request timeout in milliseconds. Defaults to 1000. */
+  timeout?: number;
 }
 
 interface ReceiptBuyer {

--- a/tests/sdkConfig.test.ts
+++ b/tests/sdkConfig.test.ts
@@ -1,0 +1,21 @@
+import FiscalSDK from "../src/index";
+
+describe("SDKConfig timeout", () => {
+  it("defaults to 1000 ms when timeout is not provided", () => {
+    const sdk = new FiscalSDK({ host: "http://localhost:4000" });
+    expect(sdk.axios.defaults.timeout).toBe(1000);
+  });
+
+  it("uses the provided timeout when set", () => {
+    const sdk = new FiscalSDK({
+      host: "http://localhost:4000",
+      timeout: 30_000,
+    });
+    expect(sdk.axios.defaults.timeout).toBe(30_000);
+  });
+
+  it("treats explicit 0 as 'no timeout' (axios convention)", () => {
+    const sdk = new FiscalSDK({ host: "http://localhost:4000", timeout: 0 });
+    expect(sdk.axios.defaults.timeout).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds an optional `timeout?: number` field to `SDKConfig`
- Constructor wires it through to `axios.create({ timeout: config.timeout ?? 1000 })`
- Default unchanged at 1000 ms — existing callers see no behavior change

## Motivation

The hardcoded 1000 ms is too short for fiscal printers under load — real Tring print latency can be 3–10 s, so the SDK times out while the device is still printing successfully. Consumers currently work around this by reaching into `sdk.axios.defaults.timeout` after construction; this makes it a first-class config option instead.

## Test plan

- [x] `new FiscalSDK({ host })` → `sdk.axios.defaults.timeout === 1000` (default preserved)
- [x] `new FiscalSDK({ host, timeout: 30_000 })` → `30_000`
- [x] `new FiscalSDK({ host, timeout: 0 })` → `0` (axios "no timeout" convention preserved)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)