### PR TITLE
fix: real device errors + expose raw request/response XML

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,36 @@ import { XMLParser } from "fast-xml-parser";
 
 const CLASSIC_DATE_FORMAT = `yyyy-MM-dd'T'hh:mm:ss`;
 
+// Build a human-readable message from a failed <KasaOdgovor>. Firmware
+// revisions disagree on the shape of an error <Odgovor>: some put a command
+// label in <Naziv> and the error text in <Vrijednost>, while others put the
+// human-readable reason in <Naziv> and a numeric status code in <Vrijednost>
+// (e.g. "Količina nije validna ! (0.001 - 999999.999)" / 408). Surfacing both
+// fields covers either convention, instead of looking up a fixed key that one
+// of them never returns — which is what produced the old "Error: undefined".
+function formatKasaError(parsed: any): string {
+  const odgovori = ([] as { Naziv?: unknown; Vrijednost?: unknown }[])
+    .concat(parsed?.KasaOdgovor?.Odgovori?.Odgovor ?? [])
+    .filter((o) => o != null);
+
+  const details = odgovori
+    .map((o) => {
+      const naziv = o?.Naziv != null ? String(o.Naziv).trim() : "";
+      const vrijednost = o?.Vrijednost != null ? String(o.Vrijednost).trim() : "";
+      if (naziv && vrijednost) return `${naziv}: ${vrijednost}`;
+      return naziv || vrijednost;
+    })
+    .filter((s) => s.length > 0)
+    .join("; ");
+
+  if (details) return details;
+
+  const type = parsed?.KasaOdgovor?.VrstaOdgovora;
+  return type
+    ? `fiscal device returned "${type}" without details`
+    : "unknown fiscal device error";
+}
+
 class FiscalSDK {
   axios: AxiosInstance;
 
@@ -57,7 +87,6 @@ class FiscalSDK {
     const parser = new XMLParser();
     const parsed = parser.parse(response.data);
 
-    console.log(parsed);
     const responses: Record<string, string> = (
       [].concat(parsed.KasaOdgovor.Odgovori.Odgovor) as {
         Naziv: string;
@@ -79,7 +108,7 @@ class FiscalSDK {
         amount: +responses.IznosFiskalnogRacuna,
       };
     } else {
-      throw new Error(`Error: ${responses["Štampanje fiskalnog računa"]}`);
+      throw new Error(formatKasaError(parsed));
     }
   }
 
@@ -117,9 +146,7 @@ class FiscalSDK {
     );
 
     if (parsed.KasaOdgovor.VrstaOdgovora !== "OK") {
-      throw new Error(
-        `Error: ${responses["Štampanje reklamiranog računa"] ?? JSON.stringify(responses)}`
-      );
+      throw new Error(formatKasaError(parsed));
     }
 
     // Docs put the new reclamation's id in BrojReklamiranogRacuna while
@@ -182,17 +209,7 @@ class FiscalSDK {
     const parsed = parser.parse(xml);
     if (parsed?.KasaOdgovor?.VrstaOdgovora === "OK") return;
 
-    const responses: Record<string, string> = (
-      [].concat(parsed?.KasaOdgovor?.Odgovori?.Odgovor ?? []) as {
-        Naziv: string;
-        Vrijednost: string;
-      }[]
-    ).reduce(
-      (acc, item) => ({ ...acc, [item.Naziv]: item.Vrijednost }),
-      {}
-    );
-    const detail = Object.values(responses).join("; ") || "unknown error";
-    throw new Error(`Error: ${commandName} failed: ${detail}`);
+    throw new Error(`${commandName} failed: ${formatKasaError(parsed)}`);
   }
 
   async writeToDisplay(params: WriteToDisplayParams = {}): Promise<void> {
@@ -253,7 +270,7 @@ class FiscalSDK {
     );
 
     if (parsed.KasaOdgovor.VrstaOdgovora !== "OK") {
-      throw new Error(`Error: ${command} failed: ${JSON.stringify(r)}`);
+      throw new Error(`${command} failed: ${formatKasaError(parsed)}`);
     }
 
     const num = (...keys: string[]): number | undefined => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import {
   FiscalError,
   FiscalSummary,
   GetDailyReportParams,
+  KasaErrorDetails,
   MoneyMovementParams,
   PrintPeriodicalReportParams,
   PrintReceiptParams,
@@ -20,33 +21,52 @@ import { XMLParser } from "fast-xml-parser";
 
 const CLASSIC_DATE_FORMAT = `yyyy-MM-dd'T'hh:mm:ss`;
 
-// Build a human-readable message from a failed <KasaOdgovor>. Firmware
-// revisions disagree on the shape of an error <Odgovor>: some put a command
-// label in <Naziv> and the error text in <Vrijednost>, while others put the
-// human-readable reason in <Naziv> and a numeric status code in <Vrijednost>
-// (e.g. "Količina nije validna ! (0.001 - 999999.999)" / 408). Surfacing both
-// fields covers either convention, instead of looking up a fixed key that one
-// of them never returns — which is what produced the old "Error: undefined".
-function formatKasaError(parsed: any): string {
+// Pull the structured device error details out of a failed <KasaOdgovor>.
+// Firmware revisions disagree on the shape of an error <Odgovor>: some put a
+// command label in <Naziv> and the error text in <Vrijednost>, while others put
+// the human-readable reason in <Naziv> and a numeric status code in
+// <Vrijednost> (e.g. "Količina nije validna ! (0.001 - 999999.999)" / 408). A
+// purely-numeric <Vrijednost> is treated as the status code; anything else is
+// error text that belongs in the message. This covers either convention,
+// instead of looking up a fixed key one of them never returns — which is what
+// produced the old "Error: undefined".
+export function parseKasaError(parsed: any): KasaErrorDetails {
   const odgovori = ([] as { Naziv?: unknown; Vrijednost?: unknown }[])
     .concat(parsed?.KasaOdgovor?.Odgovori?.Odgovor ?? [])
     .filter((o) => o != null);
 
-  const details = odgovori
+  let code: string | undefined;
+  const parts = odgovori
     .map((o) => {
       const naziv = o?.Naziv != null ? String(o.Naziv).trim() : "";
       const vrijednost = o?.Vrijednost != null ? String(o.Vrijednost).trim() : "";
+      if (vrijednost && /^\d+$/.test(vrijednost)) {
+        if (code === undefined) code = vrijednost;
+        return naziv;
+      }
       if (naziv && vrijednost) return `${naziv}: ${vrijednost}`;
       return naziv || vrijednost;
     })
-    .filter((s) => s.length > 0)
-    .join("; ");
+    .filter((s) => s.length > 0);
 
-  if (details) return details;
+  const typeRaw = parsed?.KasaOdgovor?.VrstaOdgovora;
+  const responseType =
+    typeRaw != null && String(typeRaw).trim() !== "" ? String(typeRaw).trim() : undefined;
 
-  const type = parsed?.KasaOdgovor?.VrstaOdgovora;
-  return type
-    ? `fiscal device returned "${type}" without details`
+  return {
+    deviceMessage: parts.length ? parts.join("; ") : undefined,
+    code,
+    responseType,
+  };
+}
+
+// Build a human-readable message from a failed <KasaOdgovor>, re-joining the
+// status code so the message reads the same as the device reported it.
+function formatKasaError(parsed: any): string {
+  const { deviceMessage, code, responseType } = parseKasaError(parsed);
+  if (deviceMessage) return code ? `${deviceMessage}: ${code}` : deviceMessage;
+  return responseType
+    ? `fiscal device returned "${responseType}" without details`
     : "unknown fiscal device error";
 }
 
@@ -82,6 +102,20 @@ class FiscalSDK {
       request: asString(response.config?.data),
       response: asString(response.data),
     };
+  }
+
+  // Build a FiscalError for a failed <KasaOdgovor>, carrying both the raw
+  // exchange and the structured device details so callers don't re-parse it.
+  private kasaError(
+    parsed: any,
+    response: AxiosResponse,
+    prefix?: string
+  ): FiscalError {
+    const base = formatKasaError(parsed);
+    return new FiscalError(prefix ? `${prefix}: ${base}` : base, {
+      ...this.rawExchange(response),
+      ...parseKasaError(parsed),
+    });
   }
 
   private parseTemplate(fileName: string, params: object = {}) {
@@ -126,7 +160,7 @@ class FiscalSDK {
         raw: this.rawExchange(response),
       };
     } else {
-      throw new FiscalError(formatKasaError(parsed), this.rawExchange(response));
+      throw this.kasaError(parsed, response);
     }
   }
 
@@ -164,7 +198,7 @@ class FiscalSDK {
     );
 
     if (parsed.KasaOdgovor.VrstaOdgovora !== "OK") {
-      throw new FiscalError(formatKasaError(parsed), this.rawExchange(response));
+      throw this.kasaError(parsed, response);
     }
 
     // Docs put the new reclamation's id in BrojReklamiranogRacuna while
@@ -228,10 +262,7 @@ class FiscalSDK {
     const parsed = parser.parse(response.data);
     if (parsed?.KasaOdgovor?.VrstaOdgovora === "OK") return;
 
-    throw new FiscalError(
-      `${commandName} failed: ${formatKasaError(parsed)}`,
-      this.rawExchange(response)
-    );
+    throw this.kasaError(parsed, response, `${commandName} failed`);
   }
 
   async writeToDisplay(params: WriteToDisplayParams = {}): Promise<void> {
@@ -293,10 +324,7 @@ class FiscalSDK {
     );
 
     if (parsed.KasaOdgovor.VrstaOdgovora !== "OK") {
-      throw new FiscalError(
-        `${command} failed: ${formatKasaError(parsed)}`,
-        this.rawExchange(response)
-      );
+      throw this.kasaError(parsed, response, `${command} failed`);
     }
 
     const num = (...keys: string[]): number | undefined => {
@@ -389,4 +417,4 @@ class FiscalSDK {
 
 export default FiscalSDK;
 export { FiscalError } from "./types";
-export type { RawExchange } from "./types";
+export type { RawExchange, KasaErrorDetails, FiscalErrorInfo } from "./types";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,14 @@
-import axios, { AxiosInstance } from "axios";
+import axios, { AxiosInstance, AxiosResponse, AxiosError } from "axios";
 import * as Mustache from "mustache";
 import { format } from "date-fns";
 import {
+  FiscalError,
   FiscalSummary,
   GetDailyReportParams,
   MoneyMovementParams,
   PrintPeriodicalReportParams,
   PrintReceiptParams,
+  RawExchange,
   ReceiptResult,
   ReclaimReceiptParams,
   ReclamationResult,
@@ -63,8 +65,23 @@ class FiscalSDK {
     try {
       return await this.axios.post(command, data);
     } catch (error) {
-      throw new Error("Failed to communicate with printer");
+      const response = (error as AxiosError)?.response?.data;
+      throw new FiscalError("Failed to communicate with printer", {
+        request: data,
+        response: response != null ? String(response) : undefined,
+      });
     }
+  }
+
+  // Pull the raw request/response XML off an axios response. The request body
+  // is preserved on config.data after the round-trip.
+  private rawExchange(response: AxiosResponse): RawExchange {
+    const asString = (value: unknown): string =>
+      typeof value === "string" ? value : value == null ? "" : String(value);
+    return {
+      request: asString(response.config?.data),
+      response: asString(response.data),
+    };
   }
 
   private parseTemplate(fileName: string, params: object = {}) {
@@ -106,9 +123,10 @@ class FiscalSDK {
         date: responses.DatumFiskalnogRacuna,
         time: responses.VrijemeFiskalnogRacuna,
         amount: +responses.IznosFiskalnogRacuna,
+        raw: this.rawExchange(response),
       };
     } else {
-      throw new Error(formatKasaError(parsed));
+      throw new FiscalError(formatKasaError(parsed), this.rawExchange(response));
     }
   }
 
@@ -146,7 +164,7 @@ class FiscalSDK {
     );
 
     if (parsed.KasaOdgovor.VrstaOdgovora !== "OK") {
-      throw new Error(formatKasaError(parsed));
+      throw new FiscalError(formatKasaError(parsed), this.rawExchange(response));
     }
 
     // Docs put the new reclamation's id in BrojReklamiranogRacuna while
@@ -160,6 +178,7 @@ class FiscalSDK {
       date: responses.DatumFiskalnogRacuna,
       time: responses.VrijemeFiskalnogRacuna,
       amount: +responses.IznosFiskalnogRacuna,
+      raw: this.rawExchange(response),
     };
   }
 
@@ -193,7 +212,7 @@ class FiscalSDK {
       "unosnovca",
       this.parseTemplate("cashmovement", params)
     );
-    this.assertKasaOk(response.data, "UnosNovca");
+    this.assertKasaOk(response, "UnosNovca");
   }
 
   async withdrawMoney(params: MoneyMovementParams): Promise<void> {
@@ -201,15 +220,18 @@ class FiscalSDK {
       "povratnovca",
       this.parseTemplate("cashmovement", params)
     );
-    this.assertKasaOk(response.data, "PovratNovca");
+    this.assertKasaOk(response, "PovratNovca");
   }
 
-  private assertKasaOk(xml: string, commandName: string): void {
+  private assertKasaOk(response: AxiosResponse, commandName: string): void {
     const parser = new XMLParser();
-    const parsed = parser.parse(xml);
+    const parsed = parser.parse(response.data);
     if (parsed?.KasaOdgovor?.VrstaOdgovora === "OK") return;
 
-    throw new Error(`${commandName} failed: ${formatKasaError(parsed)}`);
+    throw new FiscalError(
+      `${commandName} failed: ${formatKasaError(parsed)}`,
+      this.rawExchange(response)
+    );
   }
 
   async writeToDisplay(params: WriteToDisplayParams = {}): Promise<void> {
@@ -227,7 +249,7 @@ class FiscalSDK {
       "oi",
       this.parseTemplate("osnovneinformacije")
     );
-    return this.parseFiscalSummary(response.data, "OsnovneInformacije");
+    return this.parseFiscalSummary(response, "OsnovneInformacije");
   }
 
   async getDailyReport(params: GetDailyReportParams): Promise<FiscalSummary> {
@@ -236,7 +258,7 @@ class FiscalSDK {
       this.parseTemplate("oididnevniizvjestaj", params)
     );
     const summary = this.parseFiscalSummary(
-      response.data,
+      response,
       "ElektronskiDnevniIzvjestaj"
     );
 
@@ -244,8 +266,9 @@ class FiscalSDK {
     // BrojDI is out of range (verified on firmware v1.0.125+7661270). Detect
     // it by checking the returned Z number against the requested one.
     if (summary.zNumber !== params.brojDI) {
-      throw new Error(
-        `Daily report ${params.brojDI} not available (printer returned Z=${summary.zNumber ?? "<empty>"})`
+      throw new FiscalError(
+        `Daily report ${params.brojDI} not available (printer returned Z=${summary.zNumber ?? "<empty>"})`,
+        this.rawExchange(response)
       );
     }
 
@@ -253,11 +276,11 @@ class FiscalSDK {
   }
 
   private parseFiscalSummary(
-    xml: string,
+    response: AxiosResponse,
     command: "OsnovneInformacije" | "ElektronskiDnevniIzvjestaj"
   ): FiscalSummary {
     const parser = new XMLParser();
-    const parsed = parser.parse(xml);
+    const parsed = parser.parse(response.data);
 
     const r: Record<string, string> = (
       [].concat(parsed.KasaOdgovor.Odgovori.Odgovor) as {
@@ -270,7 +293,10 @@ class FiscalSDK {
     );
 
     if (parsed.KasaOdgovor.VrstaOdgovora !== "OK") {
-      throw new Error(`${command} failed: ${formatKasaError(parsed)}`);
+      throw new FiscalError(
+        `${command} failed: ${formatKasaError(parsed)}`,
+        this.rawExchange(response)
+      );
     }
 
     const num = (...keys: string[]): number | undefined => {
@@ -355,8 +381,12 @@ class FiscalSDK {
       taxJ: num("tax_j"),
       taxK: num("tax_k"),
       taxM: num("tax_m"),
+
+      raw: this.rawExchange(response),
     };
   }
 }
 
 export default FiscalSDK;
+export { FiscalError } from "./types";
+export type { RawExchange } from "./types";

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,34 @@ export interface SDKConfig {
   timeout?: number;
 }
 
+/** The raw XML exchanged with the device for a single command. */
+export interface RawExchange {
+  /** The XML payload sent to the device. */
+  request: string;
+  /** The XML payload returned by the device (empty if there was none). */
+  response: string;
+}
+
+/**
+ * Thrown when a command fails. Carries the raw request/response XML so callers
+ * can log or inspect the exact exchange that failed (e.g. report it to Sentry)
+ * without re-deriving it from an axios interceptor.
+ */
+export class FiscalError extends Error {
+  readonly request?: string;
+  readonly response?: string;
+
+  constructor(message: string, exchange?: Partial<RawExchange>) {
+    super(message);
+    this.name = "FiscalError";
+    this.request = exchange?.request;
+    this.response = exchange?.response;
+    // Restore the prototype chain — required for `instanceof FiscalError` to
+    // work once this is down-compiled to the package's ES5 target.
+    Object.setPrototypeOf(this, FiscalError.prototype);
+  }
+}
+
 interface ReceiptBuyer {
   // 13-char JIB/JMBG. Mandatory whenever a buyer is present — the driver
   // drops the whole Kupac block on the receipt if this is malformed.
@@ -58,6 +86,8 @@ export interface ReceiptResult {
   date: string;
   time: string;
   amount: number;
+  /** Raw request/response XML for this command. */
+  raw?: RawExchange;
 }
 
 /**
@@ -204,4 +234,7 @@ export interface FiscalSummary {
   taxJ?: number;
   taxK?: number;
   taxM?: number;
+
+  /** Raw request/response XML for this command. */
+  raw?: RawExchange;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,20 +12,40 @@ export interface RawExchange {
   response: string;
 }
 
+/** Structured device error parsed from a failed <KasaOdgovor>. */
+export interface KasaErrorDetails {
+  /** Human-readable device reason, from <Naziv> (plus non-numeric <Vrijednost>). */
+  deviceMessage?: string;
+  /** Numeric device status code, from <Vrijednost>, when present. */
+  code?: string;
+  /** <VrstaOdgovora>, e.g. "Greska". */
+  responseType?: string;
+}
+
+/** Everything that can be attached to a {@link FiscalError}. */
+export type FiscalErrorInfo = Partial<RawExchange> & KasaErrorDetails;
+
 /**
- * Thrown when a command fails. Carries the raw request/response XML so callers
- * can log or inspect the exact exchange that failed (e.g. report it to Sentry)
- * without re-deriving it from an axios interceptor.
+ * Thrown when a command fails. Carries the raw request/response XML and the
+ * structured device error (message, code, response type) so callers can show a
+ * real reason and report the exact exchange that failed (e.g. to Sentry)
+ * without re-parsing the XML themselves.
  */
 export class FiscalError extends Error {
   readonly request?: string;
   readonly response?: string;
+  readonly deviceMessage?: string;
+  readonly code?: string;
+  readonly responseType?: string;
 
-  constructor(message: string, exchange?: Partial<RawExchange>) {
+  constructor(message: string, info?: FiscalErrorInfo) {
     super(message);
     this.name = "FiscalError";
-    this.request = exchange?.request;
-    this.response = exchange?.response;
+    this.request = info?.request;
+    this.response = info?.response;
+    this.deviceMessage = info?.deviceMessage;
+    this.code = info?.code;
+    this.responseType = info?.responseType;
     // Restore the prototype chain — required for `instanceof FiscalError` to
     // work once this is down-compiled to the package's ES5 target.
     Object.setPrototypeOf(this, FiscalError.prototype);

--- a/tests/parseKasaError.test.ts
+++ b/tests/parseKasaError.test.ts
@@ -1,0 +1,70 @@
+import { XMLParser } from "fast-xml-parser";
+import { parseKasaError } from "../src/index";
+
+const parse = (xml: string) => parseKasaError(new XMLParser().parse(xml));
+
+// Real firmware: the human-readable reason sits in <Naziv> and a numeric
+// status code in <Vrijednost>.
+const CODED_ERROR = `<?xml version="1.0" encoding="utf-8"?>
+<KasaOdgovor>
+  <Odgovori>
+    <Odgovor>
+      <Naziv>Količina nije validna ! (0.001 - 999999.999)</Naziv>
+      <Vrijednost xsi:type="xsd:int">408</Vrijednost>
+    </Odgovor>
+  </Odgovori>
+  <VrstaOdgovora>Greska</VrstaOdgovora>
+</KasaOdgovor>`;
+
+// The other firmware convention: a command label in <Naziv> and the real error
+// text in <Vrijednost> (non-numeric).
+const TEXT_ERROR = `<?xml version="1.0" encoding="utf-8"?>
+<KasaOdgovor>
+  <Odgovori>
+    <Odgovor>
+      <Naziv>Štampanje fiskalnog računa</Naziv>
+      <Vrijednost xsi:type="xsd:string">ERROR_FISCAL_INVALID_ITEM_TAX</Vrijednost>
+    </Odgovor>
+  </Odgovori>
+  <VrstaOdgovora>Greska</VrstaOdgovora>
+</KasaOdgovor>`;
+
+const EMPTY_GRESKA = `<?xml version="1.0" encoding="utf-8"?>
+<KasaOdgovor>
+  <Odgovori />
+  <VrstaOdgovora>Greska</VrstaOdgovora>
+</KasaOdgovor>`;
+
+describe("parseKasaError", () => {
+  it("treats a numeric <Vrijednost> as the code and keeps <Naziv> as the reason", () => {
+    expect(parse(CODED_ERROR)).toEqual({
+      deviceMessage: "Količina nije validna ! (0.001 - 999999.999)",
+      code: "408",
+      responseType: "Greska",
+    });
+  });
+
+  it("keeps a non-numeric <Vrijednost> in the message and reports no code", () => {
+    expect(parse(TEXT_ERROR)).toEqual({
+      deviceMessage: "Štampanje fiskalnog računa: ERROR_FISCAL_INVALID_ITEM_TAX",
+      code: undefined,
+      responseType: "Greska",
+    });
+  });
+
+  it("returns only the response type when there are no Odgovor entries", () => {
+    expect(parse(EMPTY_GRESKA)).toEqual({
+      deviceMessage: undefined,
+      code: undefined,
+      responseType: "Greska",
+    });
+  });
+
+  it("returns empty details for a response with no KasaOdgovor", () => {
+    expect(parseKasaError({})).toEqual({
+      deviceMessage: undefined,
+      code: undefined,
+      responseType: undefined,
+    });
+  });
+});

--- a/tests/printReceipt.test.ts
+++ b/tests/printReceipt.test.ts
@@ -1,6 +1,6 @@
 import { rest } from "msw";
 import { setupServer } from "msw/node";
-import FiscalSDK from "../src/index";
+import FiscalSDK, { FiscalError } from "../src/index";
 
 // Test instance
 const fiscal = new FiscalSDK({
@@ -97,12 +97,35 @@ describe("Print receipt", () => {
         date: new Date(),
       });
 
-      expect(response).toStrictEqual({
+      expect(response).toMatchObject({
         amount: 10,
         date: "01.01.2023.",
         id: 420,
         time: "08:30:59",
       });
+    });
+
+    it("exposes the raw request and response XML on success", async () => {
+      const response = await fiscal.printReceipt({
+        articles: [
+          {
+            id: "1",
+            name: "Zvake",
+            price: 10,
+            rate: "E",
+            quantity: 1,
+            discount: 0,
+          },
+        ],
+        paymentMethods: [{ type: "Gotovina", amount: 10 }],
+        billId: "1",
+        date: new Date(),
+      });
+
+      expect(response.raw?.request).toContain("<RacunZahtjev");
+      expect(response.raw?.request).toContain("<Naziv>Zvake</Naziv>");
+      expect(response.raw?.response).toContain("<KasaOdgovor");
+      expect(response.raw?.response).toContain("<VrstaOdgovora>OK</VrstaOdgovora>");
     });
 
     it("includes <Kupac> block with PDVBroj when buyer.pdvNumber is set", async () => {
@@ -242,24 +265,35 @@ describe("Print receipt", () => {
     afterAll(() => server.close());
     afterEach(() => server.resetHandlers());
 
+    const params = {
+      articles: [
+        {
+          id: "1",
+          name: "Zvake",
+          price: 10,
+          rate: "E" as const,
+          quantity: 1,
+          discount: 0,
+        },
+      ],
+      paymentMethods: [{ type: "Gotovina" as const, amount: 10 }],
+      billId: "1",
+      date: new Date(),
+    };
+
     it("surfaces the device message and status code, not 'Error: undefined'", async () => {
-      await expect(
-        fiscal.printReceipt({
-          articles: [
-            {
-              id: "1",
-              name: "Zvake",
-              price: 10,
-              rate: "E",
-              quantity: 1,
-              discount: 0,
-            },
-          ],
-          paymentMethods: [{ type: "Gotovina", amount: 10 }],
-          billId: "1",
-          date: new Date(),
-        })
-      ).rejects.toThrow(/Količina nije validna.*408/);
+      await expect(fiscal.printReceipt(params)).rejects.toThrow(
+        /Količina nije validna.*408/
+      );
+    });
+
+    it("throws a FiscalError carrying the raw request and response", async () => {
+      const error = await fiscal.printReceipt(params).catch((e) => e);
+
+      expect(error).toBeInstanceOf(FiscalError);
+      expect(error.request).toContain("<RacunZahtjev");
+      expect(error.response).toContain("Količina nije validna");
+      expect(error.response).toContain("<VrstaOdgovora>Greska</VrstaOdgovora>");
     });
   });
 });

--- a/tests/printReceipt.test.ts
+++ b/tests/printReceipt.test.ts
@@ -208,7 +208,58 @@ describe("Print receipt", () => {
           billId: "1",
           date: new Date(),
         })
-      ).rejects.toThrowError("Error: ERROR_FISCAL_INVALID_ITEM_TAX");
+      ).rejects.toThrowError("ERROR_FISCAL_INVALID_ITEM_TAX");
+    });
+  });
+
+  describe("when the printer rejects with a coded error (real firmware)", () => {
+    // Real firmware puts the human-readable reason in <Naziv> and a numeric
+    // status code in <Vrijednost> — the inverse of the command-label/error-text
+    // shape the SDK originally assumed. Without surfacing <Naziv>, this used to
+    // throw the useless "Error: undefined".
+    const server = setupServer(
+      rest.post<string>(
+        "http://localhost:4000/stampatifiskalniracun",
+        async (req, res, ctx) => {
+          return res(
+            ctx.xml(`<?xml version="1.0" encoding="utf-8"?>
+      <KasaOdgovor xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <Odgovori>
+          <Odgovor>
+            <Naziv>Količina nije validna ! (0.001 - 999999.999)</Naziv>
+            <Vrijednost xsi:type="xsd:int">408</Vrijednost>
+          </Odgovor>
+        </Odgovori>
+        <VrstaOdgovora>Greska</VrstaOdgovora>
+        <BrojZahtjeva />
+      </KasaOdgovor>`)
+          );
+        }
+      )
+    );
+
+    beforeAll(() => server.listen());
+    afterAll(() => server.close());
+    afterEach(() => server.resetHandlers());
+
+    it("surfaces the device message and status code, not 'Error: undefined'", async () => {
+      await expect(
+        fiscal.printReceipt({
+          articles: [
+            {
+              id: "1",
+              name: "Zvake",
+              price: 10,
+              rate: "E",
+              quantity: 1,
+              discount: 0,
+            },
+          ],
+          paymentMethods: [{ type: "Gotovina", amount: 10 }],
+          billId: "1",
+          date: new Date(),
+        })
+      ).rejects.toThrow(/Količina nije validna.*408/);
     });
   });
 });

--- a/tests/printReceipt.test.ts
+++ b/tests/printReceipt.test.ts
@@ -295,5 +295,13 @@ describe("Print receipt", () => {
       expect(error.response).toContain("Količina nije validna");
       expect(error.response).toContain("<VrstaOdgovora>Greska</VrstaOdgovora>");
     });
+
+    it("exposes the structured device message, code, and response type", async () => {
+      const error = await fiscal.printReceipt(params).catch((e) => e);
+
+      expect(error.deviceMessage).toBe("Količina nije validna ! (0.001 - 999999.999)");
+      expect(error.code).toBe("408");
+      expect(error.responseType).toBe("Greska");
+    });
   });
 });

--- a/tests/reclaimReceipt.test.ts
+++ b/tests/reclaimReceipt.test.ts
@@ -111,7 +111,7 @@ describe("reclaimReceipt", () => {
 
   it("returns the new reclamation document's id from BrojReklamiranogRacuna (docs shape)", async () => {
     const result = await fiscal.reclaimReceipt(baseParams);
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       id: 2,
       date: "2. 10. 2023.",
       time: "08:37:33",
@@ -128,7 +128,7 @@ describe("reclaimReceipt", () => {
       )
     );
     const result = await fiscal.reclaimReceipt(baseParams);
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       id: 3,
       date: "17. 5. 2026.",
       time: "15:27",


### PR DESCRIPTION
Two related improvements to error reporting / observability. Both are covered by tests; full suite passes (`npx jest` → 7 suites, 33 tests) and `npx tsc --noEmit` is clean.

## 1. Surface the real device error instead of `Error: undefined`

The error path looked up a fixed response key (`"Štampanje fiskalnog računa"`) that not every firmware returns. Real firmware reports failures with the human-readable reason in `<Odgovor><Naziv>` and a numeric status code in `<Vrijednost>`:

```xml
<Odgovor>
  <Naziv>Količina nije validna ! (0.001 - 999999.999)</Naziv>
  <Vrijednost xsi:type="xsd:int">408</Vrijednost>
</Odgovor>
<VrstaOdgovora>Greska</VrstaOdgovora>
```

So the lookup returned `undefined` and `printReceipt` threw `Error: undefined`, discarding the actual reason. The same fragile pattern was repeated in `reclaimReceipt`, `assertKasaOk` (deposit/withdraw) and `parseFiscalSummary` (read commands).

- Add `formatKasaError(parsed)` that builds the message from the `<Odgovor>` entries, surfacing **both** `<Naziv>` and `<Vrijednost>` — so it works whether the reason is in the name or the value, covering both firmware conventions. Falls back to `<VrstaOdgovora>` when there are no details.
- Use it at all four error sites.
- Drop the redundant `Error: ` literal prefix (an `Error` already stringifies as `Error: …`).
- Remove a stray `console.log(parsed)` in `printReceipt`.

Result: `Error: undefined` → `Količina nije validna ! (0.001 - 999999.999): 408`.

## 2. Expose the raw request/response XML

Consumers that report failures (e.g. to Sentry) previously had to re-derive the exact XML via an axios interceptor. Now the SDK exposes it directly:

- New **`FiscalError`** (`extends Error`) carrying `{ request, response }`, thrown on every device rejection and on a communication failure. Exported from the entry point; `instanceof` works under the ES5 build target (prototype restored in the ctor).
- New optional **`raw: { request, response }`** on `ReceiptResult` and `FiscalSummary`, populated on success.
- The request body is read off `response.config.data` after the round-trip; a network failure still carries the `request` (and any error-response body).
- `RawExchange` type exported.

```ts
try {
  const r = await sdk.printReceipt(params);
  // r.raw.request / r.raw.response
} catch (e) {
  if (e instanceof FiscalError) {
    // e.message, e.request, e.response
  }
}
```

## Compatibility

- The pre-existing error fixtures use the command-label/error-text shape; surfacing both fields keeps them passing. The only assertion change was dropping the now-redundant `Error: ` prefix in one `printReceipt` test.
- `raw` is additive and optional; the whole-object result assertions were relaxed from `toEqual` to `toMatchObject`.
- `FiscalError extends Error`, so existing `instanceof Error` / message checks are unaffected.

> Out of scope but noticed: `CLASSIC_DATE_FORMAT` uses lowercase `hh` (12-hour) with no AM/PM token, so e.g. `14:30` formats as `02:30` in `<Datum>`. Happy to send a separate PR.
